### PR TITLE
Allow `read_testdata` to work during R CMD check

### DIFF
--- a/R/use_testdata.R
+++ b/R/use_testdata.R
@@ -126,16 +126,17 @@ read_testdata <- function(infile, subdir = NULL){
   # Preconditions
   assert_that(is.null(subdir) || (is.scalar(subdir) && is.character(subdir)))
 
-
   # Find test_data dir
-  cache_dir <- file.path(usethis::proj_get(), 'tests', 'testthat', 'testdata')
+  cache_dir <- tryCatch(
+    expr  = file.path(usethis::proj_get(), 'tests', 'testthat', 'testdata'),
+    error = function(e) file.path(getwd(), 'testdata')
+  )
 
   if(!is.null(subdir)){
     cache_dir <- file.path(cache_dir, subdir)
   }
 
   assert_that(file.exists(cache_dir))
-
 
   # Read file
   path        <- file.path(cache_dir, infile)


### PR DESCRIPTION
Fixes a minor but irritating issue: If `read_testdata("some_test_data.R")` is called in a test, then **testthis** will work great and find & return the specified test data object. However, this will fail outside of an R project -- such as during default R CMD check -- because `read_testdata()` uses `usethis::proj_get()` to create the `cache_dir` in which it looks for test data.

The fix is a really simple one-liner: just instruct `read_testdata()` to check in `file.path(getwd(), 'testdata')` in the event that  `usethis::proj_get()` fails; i.e., change:

[**Previous**:](https://github.com/s-fleck/testthis/blob/3a45a6522481f0645ba1cd364b5462314586589d/R/use_testdata.R#L130-L131)
```
  # Find test_data dir
  cache_dir <- file.path(usethis::proj_get(), 'tests', 'testthat', 'testdata')
```
to

**in Pull Request**:
```
# Find test_data dir
  cache_dir <- tryCatch(
    expr  = file.path(usethis::proj_get(), 'tests', 'testthat', 'testdata'),
    error = function(e) file.path(getwd(), 'testdata')
  )
```