### PR TITLE
Don't load helpers twice

### DIFF
--- a/R/test_this.R
+++ b/R/test_this.R
@@ -22,12 +22,14 @@ test_this <- function(...){
     rstudioapi::documentSaveAll()
   }
 
-  devtools::load_all(usethis::proj_get())
+  if (file.exists(fname)){
+    filter <- paste0("^", gsub("^.*test-([^/]*)[.][rR]$", "\\1", fname), "$")
 
-  if(file.exists(fname)){
-    message("Running tests in ", fname)
-    testthat::test_file(fname, ..., load_helpers = FALSE)
+    message("Running tests using filter: ", filter)
+    devtools::test(usethis::proj_get(), filter = filter, ...)
   } else {
+    devtools::load_all(usethis::proj_get())
+
     msg_testfile_does_not_exist(fname)
   }
 

--- a/R/test_this.R
+++ b/R/test_this.R
@@ -26,7 +26,7 @@ test_this <- function(...){
 
   if(file.exists(fname)){
     message("Running tests in ", fname)
-    testthat::test_file(fname, ...)
+    testthat::test_file(fname, ..., load_helpers = FALSE)
   } else {
     msg_testfile_does_not_exist(fname)
   }


### PR DESCRIPTION
This makes a real difference when helpers take seconds to run.

Alternative approach: Run `devtools::test(file = "...")` without an explicit `load_all()`. This would seem slightly preferable. The current code executes `load_all()` unconditionally even if the test is not found, is this expected?